### PR TITLE
Silence warning messages

### DIFF
--- a/cpp/include/RCDB/MySqlConnectionInfo.h
+++ b/cpp/include/RCDB/MySqlConnectionInfo.h
@@ -13,8 +13,8 @@ namespace rcdb
         MySQLConnectionInfo()
                 :UserName(""),
                  Password(""),
-                 HostName(""),
                  Database(""),
+                 HostName(""),
                  Port(0)
         {
         }

--- a/cpp/include/RCDB/MySqlProvider.h
+++ b/cpp/include/RCDB/MySqlProvider.h
@@ -82,8 +82,8 @@ namespace rcdb {
             static const int int_column = 3;
             static const int text_column = 4;
             static const int time_column = 5;
-            uint64_t typeId = cndType.GetId();
-            uint64_t run = runNumber;
+            //uint64_t typeId = cndType.GetId();
+            //uint64_t run = runNumber;
 
             string query = string("SELECT id, bool_value, float_value, int_value, text_value, time_value FROM conditions WHERE run_number =") +
                            to_string(runNumber) +
@@ -231,8 +231,8 @@ namespace rcdb {
                 printf("\n");
             }
 
-            (result);
-            (con);
+            //(result);
+            //(con);
         }
 
         static MySQLConnectionInfo ParseConnectionString(std::string conStr)

--- a/cpp/include/RCDB/SqLiteProvider.h
+++ b/cpp/include/RCDB/SqLiteProvider.h
@@ -79,8 +79,8 @@ namespace rcdb {
 
             _getConditionQuery.reset();
             _getConditionQuery.clearBindings();
-            _getConditionQuery.bind(1, (sqlite3_int64&)run);
-            _getConditionQuery.bind(2, (sqlite3_int64&)typeId);
+            _getConditionQuery.bind(1, (sqlite3_int64)run);
+            _getConditionQuery.bind(2, (sqlite3_int64)typeId);
 
 
             while (_getConditionQuery.executeStep()) {
@@ -127,7 +127,7 @@ namespace rcdb {
             _getFileQuery.reset();
             _getFileQuery.clearBindings();
             _getFileQuery.bind(1, name.c_str());
-            _getFileQuery.bind(2, (sqlite3_int64&)runNumber);
+            _getFileQuery.bind(2, (sqlite3_int64)runNumber);
 
 
             while (_getFileQuery.executeStep()) {
@@ -157,8 +157,8 @@ namespace rcdb {
 
             _getConditionQuery.reset();
             _getConditionQuery.clearBindings();
-            _getConditionQuery.bind(1, (sqlite3_int64&)run);
-            _getConditionQuery.bind(2, (sqlite3_int64&)typeId);
+            _getConditionQuery.bind(1, (sqlite3_int64)run);
+            _getConditionQuery.bind(2, (sqlite3_int64)typeId);
 
 
             while (_getConditionQuery.executeStep()) {

--- a/cpp/include/RCDB/StringUtils.h
+++ b/cpp/include/RCDB/StringUtils.h
@@ -201,7 +201,7 @@ public:
         //clear output
         tokens.clear();
         bool stringIsStarted = false; //Indicates that we meet '"' and looking for second one
-        bool isSlash = false; //indicates if \ sign is happen to shield the quote or anothe slash
+        //bool isSlash = false; //indicates if \ sign is happen to shield the quote or anothe slash
         std::string readValue="";
         //iterate through string
         for(size_t i=0; i<source.length(); i++)


### PR DESCRIPTION
1. Change initialization order.
2. Comment out unused variables.
3. Comment out statements that have no effect.
4. Remove "&" from type conversion.