### PR TITLE
silence warning: Comment out unused private member

### DIFF
--- a/cpp/include/RCDB/DataProvider.h
+++ b/cpp/include/RCDB/DataProvider.h
@@ -48,7 +48,7 @@ namespace rcdb {
         std::map<std::string, ConditionType> _typesByName;          /// Condition types mapped by name
 
     private:
-        bool mAreConditionTypesLoaded;
+        //bool mAreConditionTypesLoaded;
     };
 
 


### PR DESCRIPTION
This silences an extra warning I saw when building with GCC 4.9.
Previously, I was using GCC 4.8.