### PR TITLE
Sqlitecpp standalone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,7 @@ cpp/\.idea/workspace\.xml
 
 \.sconsign\.dblite
 .idea/misc.xml
+
+# build_scripts
+.clone_done
+rcdb_prereqs_version.xml

--- a/cpp/include/RCDB/SqLiteProvider.h
+++ b/cpp/include/RCDB/SqLiteProvider.h
@@ -5,8 +5,8 @@
 #ifndef RCDB_CPP_SQLITEPROVIDER_H
 #define RCDB_CPP_SQLITEPROVIDER_H
 
-
-#include <RCDB/SQLiteCpp.h>
+#include <sqlite3.h>
+#include <SQLiteCpp/SQLiteCpp.h>
 #include <iostream>
 #include <memory>
 #include "DataProvider.h"


### PR DESCRIPTION
Use SQLiteCpp from a stand-alone library build. RCDB not header-only anymore.