### PR TITLE
* fix some minor bugs in the c++ headers:

### DIFF
--- a/cpp/include/RCDB/ConfigParser.h
+++ b/cpp/include/RCDB/ConfigParser.h
@@ -41,7 +41,7 @@ namespace rcdb
         ConfigFileParseResult(std::vector<std::string> SectionNames)
         {
             for(auto sectionName: SectionNames) {
-                SectionNames.push_back(sectionName);
+                this->SectionNames.push_back(sectionName);
             }
         }
         std::vector<std::string> SectionNames;

--- a/cpp/include/RCDB/Connection.h
+++ b/cpp/include/RCDB/Connection.h
@@ -33,6 +33,7 @@ namespace rcdb{
                 Connect();
             }
         }
+        virtual ~Connection() {}
 
         void Connect()
         {


### PR DESCRIPTION
  - use *this to access a shadowed data member in constructor
  - make explicit constructor virtual to respect rules for
    C++ virtual inheritance and avoid compiler warnings. [rtj]