### PR TITLE
fix: `std::ptr_fun` is deprecated in C++11 (and removed in C++17)

### DIFF
--- a/cpp/include/RCDB/StringUtils.h
+++ b/cpp/include/RCDB/StringUtils.h
@@ -38,12 +38,12 @@ public:
 
     // trim from start (in place)
     static inline void ltrim(std::string &s) {
-        s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+        s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](char c) { return !isspace(c); }));
     }
 
     // trim from end (in place)
     static inline void rtrim(std::string &s) {
-        s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+        s.erase(std::find_if(s.rbegin(), s.rend(), [](char c) { return !isspace(c); }).base(), s.end());
     }
 
     // trim from both ends (in place)


### PR DESCRIPTION
`std::ptr_fun` is [deprecated in C++11](https://en.cppreference.com/w/cpp/utility/functional/ptr_fun), and its removal in C++17 makes consuming RCDB with a C++17-standard project difficult.

This PR replaces it with a lambda; alternatively, if C++17 is allowed, `std::not_fn` could be used.