### PR TITLE
fix: `SQLiteCpp.h` include directive and `SQLite::bind` parameter

### DIFF
--- a/cpp/include/RCDB/SQLiteCpp.h
+++ b/cpp/include/RCDB/SQLiteCpp.h
@@ -217,7 +217,7 @@ inline void invoke_with_index(F&& f, const Args& ... args)
  * @param args one or more args to bind.
  */
 template<class ...Args>
-void bind(SQLite::Statement& s, const Args& ... args)
+void bind(Statement& s, const Args& ... args)
 {
     static_assert(sizeof...(args) > 0, "please invoke bind with one or more args");
 

--- a/cpp/include/RCDB/SqLiteProvider.h
+++ b/cpp/include/RCDB/SqLiteProvider.h
@@ -6,7 +6,7 @@
 #define RCDB_CPP_SQLITEPROVIDER_H
 
 #include <sqlite3.h>
-#include <SQLiteCpp/SQLiteCpp.h>
+#include "SQLiteCpp.h"
 #include <iostream>
 #include <memory>
 #include "DataProvider.h"


### PR DESCRIPTION
I was having some trouble building with `-DRCDB_SQLITE` with [Iguana](https://github.com/JeffersonLab/iguana) (testing in https://github.com/JeffersonLab/iguana/pull/288). This PR appears to fix the build issues, but I haven't yet had a chance to test it at run-time.