### PR TITLE
fix: move `VariadicBind` to after `Statement`

### DIFF
--- a/cpp/include/RCDB/SQLiteCpp.h
+++ b/cpp/include/RCDB/SQLiteCpp.h
@@ -159,78 +159,6 @@ namespace SQLite
 
 
 }  // namespace SQLite
-/**
- * @file    VariadicBind.h
- * @ingroup SQLiteCpp
- * @brief   Convenience function for Statement::bind(...)
- *
- * Copyright (c) 2016 Paul Dreik (github@pauldreik.se)
- * Copyright (c) 2016 Sebastien Rombauts (sebastien.rombauts@gmail.com)
- *
- * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
- * or copy at http://opensource.org/licenses/MIT)
- */
-
-#if (__cplusplus >= 201402L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) ) // c++14: Visual Studio 2015
-
-
-/// @cond
-#include <initializer_list>
-
-namespace SQLite
-{
-
-/// implementation detail for variadic bind.
-namespace detail {
-template<class F, class ...Args, std::size_t ... I>
-inline void invoke_with_index(F&& f, std::integer_sequence<std::size_t, I...>, const Args& ...args)
-{
-    std::initializer_list<int> { (f(I+1, args), 0)... };
-}
-
-/// implementation detail for variadic bind.
-template<class F, class ...Args>
-inline void invoke_with_index(F&& f, const Args& ... args)
-{
-    invoke_with_index(std::forward<F>(f), std::index_sequence_for<Args...>(), args...);
-}
-
-} // namespace detail
-/// @endcond
-
-/**
- * \brief Convenience function for calling Statement::bind(...) once for each argument given.
- *
- * This takes care of incrementing the index between each calls to bind.
- *
- * This feature requires a c++14 capable compiler.
- *
- * \code{.cpp}
- * SQLite::Statement stm("SELECT * FROM MyTable WHERE colA>? && colB=? && colC<?");
- * bind(stm,a,b,c);
- * //...is equivalent to
- * stm.bind(1,a);
- * stm.bind(2,b);
- * stm.bind(3,c);
- * \endcode
- * @param s statement
- * @param args one or more args to bind.
- */
-template<class ...Args>
-void bind(Statement& s, const Args& ... args)
-{
-    static_assert(sizeof...(args) > 0, "please invoke bind with one or more args");
-
-    auto f=[&s](std::size_t index, const auto& value)
-    {
-        s.bind(index, value);
-    };
-    detail::invoke_with_index(f, args...);
-}
-
-}  // namespace SQLite
-
-#endif // c++14
 
 /**
  * @file    Statement.h
@@ -876,6 +804,81 @@ public:
 
 
 }  // namespace SQLite
+
+/**
+ * @file    VariadicBind.h
+ * @ingroup SQLiteCpp
+ * @brief   Convenience function for Statement::bind(...)
+ *
+ * Copyright (c) 2016 Paul Dreik (github@pauldreik.se)
+ * Copyright (c) 2016 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ *
+ * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
+ * or copy at http://opensource.org/licenses/MIT)
+ */
+
+#if (__cplusplus >= 201402L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) ) // c++14: Visual Studio 2015
+
+
+/// @cond
+#include <initializer_list>
+
+namespace SQLite
+{
+
+/// implementation detail for variadic bind.
+namespace detail {
+template<class F, class ...Args, std::size_t ... I>
+inline void invoke_with_index(F&& f, std::integer_sequence<std::size_t, I...>, const Args& ...args)
+{
+    std::initializer_list<int> { (f(I+1, args), 0)... };
+}
+
+/// implementation detail for variadic bind.
+template<class F, class ...Args>
+inline void invoke_with_index(F&& f, const Args& ... args)
+{
+    invoke_with_index(std::forward<F>(f), std::index_sequence_for<Args...>(), args...);
+}
+
+} // namespace detail
+/// @endcond
+
+/**
+ * \brief Convenience function for calling Statement::bind(...) once for each argument given.
+ *
+ * This takes care of incrementing the index between each calls to bind.
+ *
+ * This feature requires a c++14 capable compiler.
+ *
+ * \code{.cpp}
+ * SQLite::Statement stm("SELECT * FROM MyTable WHERE colA>? && colB=? && colC<?");
+ * bind(stm,a,b,c);
+ * //...is equivalent to
+ * stm.bind(1,a);
+ * stm.bind(2,b);
+ * stm.bind(3,c);
+ * \endcode
+ * @param s statement
+ * @param args one or more args to bind.
+ */
+template<class ...Args>
+void bind(SQLite::Statement& s, const Args& ... args)
+{
+    static_assert(sizeof...(args) > 0, "please invoke bind with one or more args");
+
+    auto f=[&s](std::size_t index, const auto& value)
+    {
+        s.bind(index, value);
+    };
+    detail::invoke_with_index(f, args...);
+}
+
+}  // namespace SQLite
+
+#endif // c++14
+
+
 /**
  * @file    Column.h
  * @ingroup SQLiteCpp


### PR DESCRIPTION
Resolves `clang++` error "member access into incomplete type 'Statement'", following up on #109.

Alternatively, do we even need this `VariadicBind` stuff here? Looking [upstream](https://github.com/SRombauts/SQLiteCpp/tree/master/include/SQLiteCpp), `VariadicBind.h` is only included in `ExecuteMany.h`, but `ExecuteMany.h` is not included in any other source or header file (besides tests and examples).